### PR TITLE
update dev deps

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -74,6 +74,16 @@ module.exports = {
     'consistent-return': 'off',
     'no-plusplus': 'off',
     indent: ['error', 2, {flatTernaryExpressions: true}],
+    'no-multiple-empty-lines': 'off',
+    'nonblock-statement-body-position': 'off',
+    'object-curly-newline': 'off',
+    'function-paren-newline': 'off',
+    'implicit-arrow-linebreak': 'off',
+    'operator-linebreak': 'off',
+    'react/destructuring-assignment': 'off',
+    'react/static-property-placement': 'off',
+    'react/jsx-one-expression-per-line': 'off',
+    'react/jsx-wrap-multilines': 'off',
   },
   settings: {
     'import/resolver': {

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
     "babel-plugin-add-module-exports": "^1.0.4",
     "babel-eslint": "^10.1.0",
     "eslint": "^7.26.0",
-    "eslint-config-airbnb": "^15.0.1",
+    "eslint-config-airbnb": "^18.0.1",
     "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jsx-a11y": "^5.1.1",
+    "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.23.2",
     "mocha": "^3.3.0"
   }


### PR DESCRIPTION
It does not affect production, but the dependency of eslint was not resolved in the development environment. This can be ignored with npm install --force, but I prefer it to work naturally.

I updated eslint-config-airbnb and eslint-plugin-jsx-a11y to the earliest versions that passed npm install successfully. 

I then adjusted .eslintrc.js to have the same code conventions as before the change. 

it warns me that I don't have the react package, but I don't think that's a problem since it's a plugin. I did not know how to suppress this warning...

---

**npm install error before change**

```
C:\src\poi-plugin-cqc>npm install --verbose

(A FEW NINUTES LATER....)

npm verb node v16.1.0
npm verb npm  v7.11.2
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: poi-plugin-cqc@0.2.0
npm ERR! Found: eslint@7.26.0
npm ERR! node_modules/eslint
npm ERR!   dev eslint@"^7.26.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer eslint@"^3.19.0 || ^4.3.0" from eslint-config-airbnb@15.1.0
npm ERR! node_modules/eslint-config-airbnb
npm ERR!   dev eslint-config-airbnb@"^15.0.1" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR! See C:\Users\root\AppData\Local\npm-cache\eresolve-report.txt for a full report.
npm verb exit 1
npm timing npm Completed in 1855ms
npm verb code 1

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\root\AppData\Local\npm-cache\_logs\2021-05-19T11_00_51_067Z-debug.log
```


---

**lint before change**

```
C:\src\poi-plugin-cqc>.\node_modules\.bin\eslint.cmd **/*.es -c .\.eslintrc.js

C:\src\poi-plugin-cqc\cqc\fleet\fighter-power.es
  12:19  error  'fleet' is defined but never used. Allowed unused args must match /^_[a-zA-Z].*/u  no-unused-vars

✖ 1 problem (1 error, 0 warnings)
```

---

**lint after changed**

```
C:\src\poi-plugin-cqc>.\node_modules\.bin\eslint.cmd **/*.es -c .\.eslintrc.js
Warning: React version was set to "detect" in eslint-plugin-react settings, but the "react" package is not installed. Assuming latest React version for linting.

C:\src\poi-plugin-cqc\cqc\fleet\fighter-power.es
  12:19  error  'fleet' is defined but never used. Allowed unused args must match /^_[a-zA-Z].*/u  no-unused-vars

✖ 1 problem (1 error, 0 warnings)

```

