### PR TITLE
Export airbase info via DeckBuilder (Clipboard)

### DIFF
--- a/ui/toolbar/index.es
+++ b/ui/toolbar/index.es
@@ -65,12 +65,16 @@ class ToolbarImpl extends PureComponent {
     shell.openExternal(`https://noro6.github.io/kc-web#import:${encoded}`)
   }
 
-  handleExportDeckBuilderClipboard = () => {
+  handleExportDeckBuilderClipboard = async () => {
     const {compo} = this.props
-    const encoded = JSON.stringify(cqcToDeckBuilder(compo))
-    clipboard.writeText(encoded)
-    const {success} = window
-    success(`Copied to clipboard (${new Date()})`)
+    const encoded = JSON.stringify(cqcToAircalcDeckBuilder(compo))
+    try {
+      await navigator.clipboard.writeText(encoded)
+      const {success} = window
+      success(`Copied to clipboard (${new Date()})`)
+    } catch (err) {
+      console.error('Failed to copy to clipboard:', err)
+    }
   }
 
   handleExportWctf = () => {

--- a/ui/toolbar/index.es
+++ b/ui/toolbar/index.es
@@ -67,7 +67,7 @@ class ToolbarImpl extends PureComponent {
 
   handleExportDeckBuilderClipboard = () => {
     const {compo} = this.props
-    const encoded = JSON.stringify(cqcToDeckBuilder(compo))
+    const encoded = JSON.stringify(cqcToAircalcDeckBuilder(compo))
     clipboard.writeText(encoded)
     const {success} = window
     success(`Copied to clipboard (${new Date()})`)


### PR DESCRIPTION
Updates `ui/toolbar/index.es` to use `cqcToAircalcDeckBuilder` in `handleExportDeckBuilderClipboard`, ensuring that the "DeckBuilder (Clipboard)" functionality exports the airbase data as well as fleet and equipment information, in accordance with the format supported by noro6's Aircalc simulator.